### PR TITLE
Adds auto-role selection

### DIFF
--- a/src/providers/jumpcloud.rs
+++ b/src/providers/jumpcloud.rs
@@ -120,7 +120,7 @@ impl JumpcloudProvider {
 
         debug!("Text for SAML response: {:#?}", input);
 
-        let credentials = saml::get_credentials_from_saml(input)?;
+        let credentials = saml::get_credentials_from_saml(input, profile.role.clone())?;
 
         trace!("Credentials: {:#?}", credentials);
         Ok(credentials)

--- a/src/providers/okta.rs
+++ b/src/providers/okta.rs
@@ -68,7 +68,7 @@ impl OktaProvider {
 
         debug!("Text for SAML response: {:#?}", input);
 
-        let credentials = saml::get_credentials_from_saml(input)?;
+        let credentials = saml::get_credentials_from_saml(input, profile.role.clone())?;
         trace!("Credentials: {:?}", credentials);
         Ok(credentials)
     }

--- a/src/saml.rs
+++ b/src/saml.rs
@@ -51,7 +51,7 @@ impl FromStr for Response {
     }
 }
 
-pub fn get_credentials_from_saml(input: String) -> Result<AwsCredentials> {
+pub fn get_credentials_from_saml(input: String, role: Option<String>) -> Result<AwsCredentials> {
     let saml = extract_saml_assertion(&input)?;
 
     debug!("SAML response: {:?}", &saml);
@@ -60,7 +60,7 @@ pub fn get_credentials_from_saml(input: String) -> Result<AwsCredentials> {
 
     debug!("SAML Roles: {:?}", &roles);
 
-    let role = utils::select_role(roles)?;
+    let role = utils::select_role(roles, role)?;
 
     let assumption_response =
         RoleManager::assume_role(&role, saml.raw).with_context(|| "Error assuming role")?;
@@ -71,6 +71,7 @@ pub fn get_credentials_from_saml(input: String) -> Result<AwsCredentials> {
         })?,
     ))
 }
+
 pub fn extract_saml_assertion(text: &str) -> Result<Response> {
     let document = Document::from(text);
     let node = document.find(Attr("name", "SAMLResponse")).next();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -69,7 +69,11 @@ pub fn select_role(roles: HashSet<AwsRole>, role: Option<String>) -> Result<AwsR
             r => Select::with_theme(&SimpleTheme)
                 .with_prompt("Select the role to assume:")
                 .default(0)
-                .items(&r.iter().map(|r| r.clone().role_arn) .collect::<Vec<String>>())
+                .items(
+                    &r.iter()
+                        .map(|r| r.clone().role_arn)
+                        .collect::<Vec<String>>(),
+                )
                 .interact()
                 .unwrap(),
         },
@@ -77,9 +81,15 @@ pub fn select_role(roles: HashSet<AwsRole>, role: Option<String>) -> Result<AwsR
             None => match roles.clone() {
                 r if r.len() < 2 => 0,
                 r => Select::with_theme(&SimpleTheme)
-                    .with_prompt(&format!("Role {} not found; select the role to assume:", role).to_string())
+                    .with_prompt(
+                        &format!("Role {} not found; select the role to assume:", role).to_string(),
+                    )
                     .default(0)
-                    .items(&r.iter().map(|r| r.clone().role_arn) .collect::<Vec<String>>())
+                    .items(
+                        &r.iter()
+                            .map(|r| r.clone().role_arn)
+                            .collect::<Vec<String>>(),
+                    )
                     .interact()
                     .unwrap(),
             },


### PR DESCRIPTION
When a crowbar profile has a role pre-selected, then the principle of
least surprise implies that said role will be pre-selected (if
available) from the list of roles presented by the SAML response.
Without this, the usability as a `credential_process` in an AWS config
file is pretty limited.

*Note*: This was only tested for Okta, so YMMV with other providers.