### PR TITLE
Listening to clippy

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,10 +154,7 @@ fn get_matches() -> ArgMatches<'static> {
 pub fn config() -> Result<CliConfig> {
     let matches = get_matches();
     let cli_action = select_action(&matches);
-    let location = match matches.value_of("config") {
-        Some(c) => Some(c.to_owned()),
-        _ => None,
-    };
+    let location = matches.value_of("config").map(|c| c.to_owned());
     let log_level_from_matches = matches.value_of("log-level").unwrap();
 
     Ok(CliConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ impl CrowbarConfig {
     pub fn add_profile(mut self, profile: &AppProfile) -> Result<CrowbarConfig> {
         // We use our own function here instead of contains() to only
         // filter on the name attribute
-        if find_duplicate(&self.profiles, &profile) {
+        if find_duplicate(&self.profiles, profile) {
             return Err(anyhow!(
                 "Profile with the name {} already exists",
                 profile.name

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -35,10 +35,7 @@ impl<'a> From<&ArgMatches<'a>> for AppProfile {
             name: action.value_of("profile").unwrap().to_owned(),
             username: action.value_of("username").unwrap().to_owned(),
             url: action.value_of("url").unwrap().to_owned(),
-            role: match action.value_of("role") {
-                Some(r) => Some(r.to_owned()),
-                None => None,
-            },
+            role: action.value_of("role").map(|r| r.to_owned()),
             provider: ProviderType::from_str(action.value_of("provider").unwrap()).unwrap(),
         }
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -20,7 +20,7 @@ impl fmt::Display for CredentialType {
 }
 
 pub trait Credential<T, U> {
-    fn new(profile: &T) -> Result<U>;
+    fn create(profile: &T) -> Result<U>;
     fn load(profile: &T) -> Result<U>;
     fn write(self, profile: &T) -> Result<U>;
     fn delete(self, profile: &T) -> Result<U>;

--- a/src/credentials/aws.rs
+++ b/src/credentials/aws.rs
@@ -31,7 +31,7 @@ impl AwsCredentials {
     pub fn is_expired(&self) -> bool {
         match &self.expiration {
             Some(dt) => {
-                let expiration = DateTime::parse_from_rfc3339(&dt).unwrap();
+                let expiration = DateTime::parse_from_rfc3339(dt).unwrap();
                 expiration.signed_duration_since(Utc::now()).num_seconds() < SECONDS_TO_EXPIRATION
             }
             _ => false,
@@ -70,13 +70,13 @@ impl From<HashMap<String, Option<String>>> for AwsCredentials {
     }
 }
 
-impl Into<HashMap<String, Option<String>>> for AwsCredentials {
-    fn into(self) -> HashMap<String, Option<String>> {
+impl From<AwsCredentials> for HashMap<String, Option<String>> {
+    fn from(creds: AwsCredentials) -> HashMap<String, Option<String>> {
         [
-            ("access_key_id".to_string(), self.access_key_id),
-            ("secret_access_key".to_string(), self.secret_access_key),
-            ("session_token".to_string(), self.session_token),
-            ("expiration".to_string(), self.expiration),
+            ("access_key_id".to_string(), creds.access_key_id),
+            ("secret_access_key".to_string(), creds.secret_access_key),
+            ("session_token".to_string(), creds.session_token),
+            ("expiration".to_string(), creds.expiration),
         ]
         .iter()
         .cloned()
@@ -190,7 +190,7 @@ pub fn fetch_aws_credentials(
             .and_then(|creds| creds.delete(profile).map_err(|e| debug!("{}", e)));
     }
 
-    let mut aws_credentials = AwsCredentials::load(&profile).unwrap_or_default();
+    let mut aws_credentials = AwsCredentials::load(profile).unwrap_or_default();
 
     if !aws_credentials.valid() || aws_credentials.is_expired() {
         aws_credentials = match profile.provider {

--- a/src/credentials/aws.rs
+++ b/src/credentials/aws.rs
@@ -104,7 +104,7 @@ impl fmt::Display for AwsCredentials {
 }
 
 impl Credential<AppProfile, AwsCredentials> for AwsCredentials {
-    fn new(_profile: &AppProfile) -> Result<AwsCredentials> {
+    fn create(_profile: &AppProfile) -> Result<AwsCredentials> {
         Ok(AwsCredentials::default())
     }
 

--- a/src/credentials/config.rs
+++ b/src/credentials/config.rs
@@ -28,7 +28,7 @@ impl Credential<AppProfile, ConfigCredentials> for ConfigCredentials {
 
         debug!("Trying to load credentials from ID {}", &service);
 
-        let password = Keyring::new(&service, &username)
+        let password = Keyring::new(&service, username)
             .get_password()
             .map_err(|e| anyhow!("{}", e))?;
 
@@ -48,7 +48,7 @@ impl Credential<AppProfile, ConfigCredentials> for ConfigCredentials {
             profile.base_url()?.host().unwrap()
         );
 
-        Keyring::new(&service, &username)
+        Keyring::new(service, username)
             .set_password(password)
             .map_err(|e| anyhow!("{}", e))?;
 

--- a/src/credentials/config.rs
+++ b/src/credentials/config.rs
@@ -11,7 +11,7 @@ pub struct ConfigCredentials {
 }
 
 impl Credential<AppProfile, ConfigCredentials> for ConfigCredentials {
-    fn new(profile: &AppProfile) -> Result<ConfigCredentials> {
+    fn create(profile: &AppProfile) -> Result<ConfigCredentials> {
         let credential_type = CredentialType::Config;
         let password = utils::prompt_password(profile)?;
 

--- a/src/providers/adfs.rs
+++ b/src/providers/adfs.rs
@@ -55,7 +55,7 @@ impl AdfsProvider {
         let profile = &self.profile;
 
         let config_credentials =
-            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::new(profile))?;
+            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::create(profile))?;
 
         let username = self.profile.username.clone();
         let password = config_credentials.password;

--- a/src/providers/jumpcloud.rs
+++ b/src/providers/jumpcloud.rs
@@ -69,7 +69,7 @@ impl JumpcloudProvider {
         let profile = &self.profile;
 
         let config_credentials =
-            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::new(profile))?;
+            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::create(profile))?;
 
         let response: XsrfResponse = self
             .client

--- a/src/providers/okta.rs
+++ b/src/providers/okta.rs
@@ -33,7 +33,7 @@ impl OktaProvider {
     pub fn new_session(&mut self) -> Result<&Self> {
         let profile = &self.profile;
         let config_credentials =
-            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::new(profile))?;
+            ConfigCredentials::load(profile).or_else(|_| ConfigCredentials::create(profile))?;
 
         let username = &profile.username;
         let password = &config_credentials.password;

--- a/src/providers/okta/auth.rs
+++ b/src/providers/okta/auth.rs
@@ -139,13 +139,13 @@ impl Client {
         links: &HashMap<String, Links>,
         req: &VerificationRequest,
     ) -> Result<Response> {
-        let mut verification_response = self.poll(links, &req)?;
+        let mut verification_response = self.poll(links, req)?;
         let time_at_execution = Utc::now();
         let mut tick = String::new();
         let term = Term::stderr();
 
         while timeout_not_reached(time_at_execution) {
-            verification_response = self.poll(links, &req)?;
+            verification_response = self.poll(links, req)?;
             term.clear_last_lines(1)?;
 
             match verification_response.factor_result.clone() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,9 +18,9 @@ pub enum LevelFilter {
     Trace,
 }
 
-impl Into<LogLevelFilter> for LevelFilter {
-    fn into(self) -> LogLevelFilter {
-        match self {
+impl From<LevelFilter> for LogLevelFilter {
+    fn from(level_filter: LevelFilter) -> LogLevelFilter {
+        match level_filter {
             LevelFilter::Debug => LogLevelFilter::Debug,
             LevelFilter::Warn => LogLevelFilter::Warn,
             LevelFilter::Error => LogLevelFilter::Error,


### PR DESCRIPTION
There are two commits here.

In the first, I mechanically applied Clippy's advice for code clarity.

In the second, I renamed a `new` function on the Credentials trait to avoid breaking with Rust conventions for `new`, as [flagged by Clippy](https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self).